### PR TITLE
fix(analysis): Исправление использования устаревшей команды для форматирования

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -41,11 +41,12 @@ jobs:
         run: |
           dart pub global activate dependency_validator
           dart pub global run dependency_validator:dependency_validator
+          
       - name: Run analyzer
         run: flutter analyze --fatal-warnings --fatal-infos .
 
       - name: Run formatter
-        run: flutter format --set-exit-if-changed .
+        run: dart format --set-exit-if-changed .
 
       - name: Run package analyzer
         uses: axel-op/dart-package-analyzer@v3


### PR DESCRIPTION
Команду `flutter format` поместили за deprecated, теперь при вызове этой команды выбрасывается ошибка, теперь для форматирования используется `dart format` с аналогичным синтаксисом.