### PR TITLE
feat(SNP-744): Add example localization file generation step

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -62,7 +62,7 @@ jobs:
           dart pub global activate dependency_validator
           dart pub global run dependency_validator:dependency_validator
 
-      - name: Install dependencies and generate example localization files for example
+      - name: Install dependencies and generate localization files for example
         run: cd example && flutter pub get && cd ..
 
       - name: Run analyzer

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -62,8 +62,8 @@ jobs:
           dart pub global activate dependency_validator
           dart pub global run dependency_validator:dependency_validator
 
-      - name: Generate example localization files
-        run: cd example && flutter gen-l10n && cd ..
+      - name: Install dependencies and generate example localization files for example
+        run: cd example && flutter pub get && cd ..
 
       - name: Run analyzer
         run: flutter analyze --fatal-warnings --fatal-infos .

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -62,6 +62,9 @@ jobs:
           dart pub global activate dependency_validator
           dart pub global run dependency_validator:dependency_validator
 
+      - name: Generate example localization files
+        run: cd example && flutter gen-l10n && cd ..
+
       - name: Run analyzer
         run: flutter analyze --fatal-warnings --fatal-infos .
 


### PR DESCRIPTION
Generating localization files is necessary for examples with localization to prevent errors when we run `flutter analyze`.
Otherwise there will be errors like these:
<img width="1070" alt="изображение" src="https://github.com/surfstudio/flutter-ci-workflows/assets/23572568/34abdaa9-3cdc-4b5b-bb04-5301a58d68c5">
